### PR TITLE
correct 5-digit code generation

### DIFF
--- a/lib/twilio-auth-service.js
+++ b/lib/twilio-auth-service.js
@@ -30,7 +30,7 @@ var TwilioAuthService = function() {
     }
 
     function __generateCode() {
-        return Math.floor(Math.random() * 100000);
+        return Math.floor(Math.random()*90000) + 10000;
     };
 
     function __sendCode(to, body) {


### PR DESCRIPTION
Updated function to generate random 5-digit code.

It was not working as expected, it creates 4-digit code sometimes. To test it, just run it multiple times, it returns 4-digit in about 10% of cases.
